### PR TITLE
feat: add new 'authoringTool' property to rlrr schema

### DIFF
--- a/PDUtilities/midiconvert.py
+++ b/PDUtilities/midiconvert.py
@@ -25,7 +25,8 @@ import copy
 class MidiConverter:
     def __init__(self):
         self.out_dict = {
-            'version' : 0.5,
+            'version' : 0.7,
+            'authoringTool': 'ParadiddleUtilities MidiConverter',
             'recordingMetadata' : {},
             'audioFileData' : {},
             'instruments' : [],
@@ -123,7 +124,6 @@ class MidiConverter:
         return (track_to_convert, default_index)
 
     def analyze_midi_file(self):
-        self.out_dict["version"] = 0.6
         self.out_dict["instruments"] = []
         self.out_dict["events"] = []
         self.out_dict["bpmEvents"] = []

--- a/docs/rlrrschema.json
+++ b/docs/rlrrschema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://paradiddleapp.com/schemas/rlrrschema_v0.5.json",
+    "$id": "http://paradiddleapp.com/schemas/rlrrschema_v0.7.json",
     "$comment": "TODO - Update to latest, Add optional values here such as MIDI notes etc.",
     "title": "Paradiddle RLRR Schema",
     "description": "Json schema for .rlrr format used in Paradiddle instrument kit and recording save files.",
@@ -12,6 +12,9 @@
     "properties": {
         "version": {
             "type": "number"
+        },
+        "authoringTool": {
+          "type": "string"
         },
         "instruments": {
             "type": "array",


### PR DESCRIPTION
This PR adds a new field, "authoringTool", to the RLRR schema.

The intent is to provide this information to the eventual end-user on sites like ParaDB, where custom maps might be authored using a variety of tools (hand mapped vs auto converted, etc). Currently, without an explicit field on the map file, ParaDB needs to infer it via heuristics or extra properties produced by ParEdit that aren't part of the schema. 

I've bumped the RLRR version to 0.7 - not sure if that is actually correct or out of date.